### PR TITLE
freecad: Ignore global gitconfig

### DIFF
--- a/freecad/snapcraft.yaml
+++ b/freecad/snapcraft.yaml
@@ -181,3 +181,4 @@ apps:
   environment:
       GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates
       GIT_EXEC_PATH: $SNAP/usr/lib/git-core
+      GIT_CONFIG_NOSYSTEM: 1


### PR DESCRIPTION
If a global /etc/gitconfig exists, git inside the sandbox will attempt to read it.
However, this is forbidden and thus git inside the snap fails with:

warning: unable to access '/etc/gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files

As a result, the addon manager gets stuck at the "Cloning module..." stage.
Prevent this by telling git to ignore the global config, which is not necessary at all
to download the addons.